### PR TITLE
Add new lp_login flag to enable launchpad login

### DIFF
--- a/lp2gh/client.py
+++ b/lp2gh/client.py
@@ -16,6 +16,7 @@ gflags.DEFINE_string('bugs_map', None,
                      'file with mapping data for bugs')
 gflags.DEFINE_string('blueprints_map', None,
                      'file with mapping data for blueprints')
+gflags.DEFINE_boolean('lp_login', False, 'login to launchpad to access private projects')
 
 
 class Client():
@@ -28,8 +29,12 @@ class Client():
             cachedir = os.path.abspath('./cachedir')
             if not os.path.exists(cachedir):
                 os.mkdir(cachedir)
-            lp = launchpad.Launchpad.login_anonymously(
-                'lp2gh', 'production', cachedir, version='devel')
+            if FLAGS.lp_login:
+                lp = launchpad.Launchpad.login_with(
+                    'lp2gh', 'production', cachedir, version='devel')
+            else:
+                lp = launchpad.Launchpad.login_anonymously(
+                    'lp2gh', 'production', cachedir, version='devel')
             self.__conn = lp
         return self.__conn
 

--- a/pip-requires
+++ b/pip-requires
@@ -1,1 +1,6 @@
 python-gflags
+six
+jinja2
+requests
+keyring
+launchpadlib


### PR DESCRIPTION
The original tool accesses launchpad anonymously, which limits its usage to only migrating public projects. 

This PR adds a new argument flag `lp_login`. When this flag is used, the client connection will be established via`launchpadlib.launchpad.Launchpad.login_with()`, which opens up browser for user login if no valid OAuth token exists. This token will then be stored and reused for sequential calls. 

Example usage:
```
PYTHONPATH=$(pwd) bin/lp2gh-export-bugs --lp_login lp_project > my-bug.json
```

Note: when logging in for the first time with the above command, some unwanted texts will be piped into json file. To overcome this, simply run the command again.